### PR TITLE
Drop support for Django 3.2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
         "editor.defaultFormatter": "vscode.json-language-features"
     },
     "[python]": {
-        "editor.defaultFormatter": "ms-python.python"
+        "editor.defaultFormatter": "charliermarsh.ruff"
     },
     "html.format.endWithNewline": true,
     "files.insertFinalNewline": true

--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,6 @@ Django Database Backup
         :target: https://django-dbbackup.readthedocs.io/
         :alt: Documentation Status
 
-.. image:: https://codecov.io/gh/Archmonger/django-dbbackup/branch/master/graph/badge.svg?token=zaYmStcsuX
-        :target: https://codecov.io/gh/Archmonger/django-dbbackup
-
 This Django application provides management commands to help backup and
 restore your project database and media files with various storages such as
 Amazon S3, Dropbox, local file storage or any Django storage.
@@ -51,4 +48,3 @@ We use GitHub Actions as continuous integration tools.
 .. _`Read The Docs`: https://django-dbbackup.readthedocs.org/
 .. _`GitHub issues`: https://github.com/Archmonger/django-dbbackup/issues
 .. _`pull requests`: https://github.com/Archmonger/django-dbbackup/pulls
-.. _Coveralls: https://coveralls.io/github/Archmonger/django-dbbackup

--- a/dbbackup/checks.py
+++ b/dbbackup/checks.py
@@ -48,6 +48,16 @@ W008 = Warning(
     "Did you mean to change the value for 'location'?",
     id="dbbackup.W007",
 )
+W009 = Warning(
+    "Using removed DBBACKUP_STORAGE parameter",
+    hint="settings.DBBACKUP_STORAGE has been removed in favor of settings.STORAGES['dbbackup']",
+    id="dbbackup.W009",
+)
+W010 = Warning(
+    "Using removed DBBACKUP_STORAGE_OPTIONS parameter",
+    hint="settings.DBBACKUP_STORAGE_OPTIONS has been removed in favor of settings.STORAGES['dbbackup']['OPTIONS']",
+    id="dbbackup.W010",
+)
 
 
 def check_filename_templates():
@@ -106,5 +116,11 @@ def check_settings(app_configs, **kwargs):
         errors.append(W006)
 
     errors += check_filename_templates()
+
+    if getattr(settings, "DBBACKUP_STORAGE", None) is not None:
+        errors.append(W009)
+
+    if getattr(settings, "DBBACKUP_STORAGE_OPTIONS", None) is not None:
+        errors.append(W010)
 
     return errors

--- a/dbbackup/settings.py
+++ b/dbbackup/settings.py
@@ -35,23 +35,13 @@ MEDIA_FILENAME_TEMPLATE = getattr(
 GPG_ALWAYS_TRUST = getattr(settings, "DBBACKUP_GPG_ALWAYS_TRUST", False)
 GPG_RECIPIENT = GPG_ALWAYS_TRUST = getattr(settings, "DBBACKUP_GPG_RECIPIENT", None)
 
-STORAGE = getattr(settings, "DBBACKUP_STORAGE", None)
-STORAGE_OPTIONS = getattr(settings, "DBBACKUP_STORAGE_OPTIONS", {})
-# https://docs.djangoproject.com/en/5.1/ref/settings/#std-setting-STORAGES
 STORAGES_DBBACKUP_ALIAS = "dbbackup"
 DJANGO_STORAGES = getattr(settings, "STORAGES", {})
-django_dbbackup_storage = DJANGO_STORAGES.get(STORAGES_DBBACKUP_ALIAS, {})
-
-if not STORAGE:
-    STORAGE = (
-        django_dbbackup_storage.get("BACKEND")
-        or "django.core.files.storage.FileSystemStorage"
-    )
-if not STORAGE_OPTIONS:
-    STORAGE_OPTIONS = django_dbbackup_storage.get("OPTIONS") or STORAGE_OPTIONS
+storage: dict = DJANGO_STORAGES.get(STORAGES_DBBACKUP_ALIAS, {})
+STORAGE = storage.get("BACKEND", "django.core.files.storage.FileSystemStorage")
+STORAGE_OPTIONS = storage.get("OPTIONS", {})
 
 CONNECTORS = getattr(settings, "DBBACKUP_CONNECTORS", {})
-
 CUSTOM_CONNECTOR_MAPPING = getattr(settings, "DBBACKUP_CONNECTOR_MAPPING", {})
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/dbbackup/storage.py
+++ b/dbbackup/storage.py
@@ -14,11 +14,11 @@ def get_storage(path=None, options=None):
     Get the specified storage configured with options.
 
     :param path: Path in Python dot style to module containing the storage
-                 class. If empty settings.DBBACKUP_STORAGE will be used.
+                 class. If empty settings.STORAGES["dbbackup"] will be used.
     :type path: ``str``
 
     :param options: Parameters for configure the storage, if empty
-                    settings.DBBACKUP_STORAGE_OPTIONS will be used.
+                    settings.STORAGES["dbbackup"]["OPTIONS"] will be used.
     :type options: ``dict``
 
     :return: Storage configured
@@ -28,7 +28,7 @@ def get_storage(path=None, options=None):
     options = options or settings.STORAGE_OPTIONS
     if not path:
         raise ImproperlyConfigured(
-            "You must specify a storage class using " "DBBACKUP_STORAGE settings."
+            'You must specify a storage class using settings.STORAGES["dbbackup"] settings.'
         )
     return Storage(path, **options)
 
@@ -59,7 +59,7 @@ class Storage:
         Initialize a Django Storage instance with given options.
 
         :param storage_path: Path to a Django Storage class with dot style
-                             If ``None``, ``settings.DBBACKUP_STORAGE`` will
+                             If ``None``, ``settings.STORAGES["dbbackup"]`` will
                              be used.
         :type storage_path: str
         """

--- a/dbbackup/tests/settings.py
+++ b/dbbackup/tests/settings.py
@@ -55,24 +55,20 @@ SERVER_EMAIL = "dbbackup@test.org"
 DBBACKUP_GPG_RECIPIENT = "test@test"
 DBBACKUP_GPG_ALWAYS_TRUST = (True,)
 
-DBBACKUP_STORAGE = os.environ.get("STORAGE", "dbbackup.tests.utils.FakeStorage")
-DBBACKUP_STORAGE_OPTIONS = dict(
-    [
-        keyvalue.split("=")
-        for keyvalue in os.environ.get("STORAGE_OPTIONS", "").split(",")
-        if keyvalue
-    ]
-)
-
-# For testing the new storages setting introduced in Django 4.2
 STORAGES = {
     "default": {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
         "OPTIONS": {},
     },
     "dbbackup": {
-        "BACKEND": DBBACKUP_STORAGE,
-        "OPTIONS": DBBACKUP_STORAGE_OPTIONS,
+        "BACKEND": os.environ.get("STORAGE", "dbbackup.tests.utils.FakeStorage"),
+        "OPTIONS": dict(
+            [
+                keyvalue.split("=")
+                for keyvalue in os.environ.get("STORAGE_OPTIONS", "").split(",")
+                if keyvalue
+            ]
+        ),
     },
 }
 

--- a/dbbackup/tests/test_storage.py
+++ b/dbbackup/tests/test_storage.py
@@ -26,15 +26,14 @@ class Get_StorageTest(TestCase):
         storage = get_storage(options=STORAGE_OPTIONS)
         self.assertIn(
             storage.storage.__module__,
-            # TODO: Remove "django.core.files.storage" case when dropping support for Django < 4.2.
-            ("django.core.files.storage", "django.core.files.storage.filesystem"),
+            {"django.core.files.storage.filesystem"},
         )
 
     def test_get_storage_class(self):
         storage_class = get_storage_class(DEFAULT_STORAGE_PATH)
         self.assertIn(
             storage_class.__module__,
-            ("django.core.files.storage", "django.core.files.storage.filesystem"),
+            {"django.core.files.storage.filesystem"},
         )
         self.assertIn(storage_class.__name__, ("FileSystemStorage", "DefaultStorage"))
 
@@ -46,7 +45,7 @@ class Get_StorageTest(TestCase):
         storage_class = get_storage_class()
         self.assertIn(
             storage_class.__module__,
-            ("django.core.files.storage", "django.core.files.storage.filesystem"),
+            {"django.core.files.storage"},
         )
         self.assertIn(storage_class.__name__, ("FileSystemStorage", "DefaultStorage"))
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Unreleased
 * This repository has been transferred out of Jazzband due to logistical concerns.
 * Drop support for end-of-life Python 3.7 and 3.8.
 * Drop support for end-of-life Django 3.2.
+* Drop support for ``DBBACKUP_STORAGE`` AND  ``DBBACKUP_STORAGE_OPTIONS`` settings, use Django's ``STORAGES['dbbackup']`` setting instead.
 
 4.3.0 (2025-05-09)
 ----------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Unreleased
 * Use environment variable for PostgreSQL password to prevent password leakage in logs/emails
 * This repository has been transferred out of Jazzband due to logistical concerns.
 * Drop support for end-of-life Python 3.7 and 3.8.
+* Drop support for end-of-life Django 3.2.
 
 4.3.0 (2025-05-09)
 ----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,13 +29,6 @@ Contents:
    contributing
    changelog
 
-Compatibility
--------------
-
-As we want to ensure a lot of platforms will be able to save data before
-upgrading, Django-DBBackup supports PyPy, 3.2 to 3.5 and Django
-greater than 3.2.
-
 Other Resources
 ===============
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -37,8 +37,14 @@ In your ``settings.py``, make sure you have the following things: ::
         'dbbackup',  # django-dbbackup
     )
 
-    DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
-    DBBACKUP_STORAGE_OPTIONS = {'location': '/my/backup/dir/'}
+    STORAGES = {
+        'dbbackup': {
+            'BACKEND': 'django.core.files.storage.FileSystemStorage',
+            'OPTIONS': {
+                'location': '/my/backup/dir/',
+            },
+        },
+    }
 
 Create the backup directory: ::
 

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -5,16 +5,14 @@ One of the most helpful features of django-dbbackup is the ability to store
 and retrieve backups from a local or a remote storage. This functionality is
 mainly based on Django Storage API and extends its possibilities.
 
-You can choose your backup storage backend by setting ``settings.DBBACKUP_STORAGE``,
+You can choose your backup storage backend by setting ``settings.STORAGES['dbbackup']``,
 it must be the full path of a storage class. For example:
 ``django.core.files.storage.FileSystemStorage`` to use file system storage. 
 Below, we'll list some of the available solutions and their options.
 
 
-The storage's option are gathered in ``settings.DBBACKUP_STORAGE_OPTIONS`` which
+The storage's option are gathered in ``settings.STORAGES['dbbackup']['OPTIONS']`` which
 is a dictionary of keywords representing how to configure it.
-
-Since Django 4.2 there is a new way to configure storages using the STORAGES setting. E.g.:::
 
     STORAGES = {
         "default": {
@@ -27,10 +25,6 @@ Since Django 4.2 there is a new way to configure storages using the STORAGES set
             ...
         },
     }
-
-instead of the previous DEFAULT_FILE_STORAGE and STATICFILES_STORAGE settings. 
-If ``settings.DBBACKUP_STORAGE`` is not set, django-dbbackup will look for the ``dbbackup`` key in the ``STORAGES`` dictionary setting.
-Otherwise, the default storage will be used.
 
 
 .. warning::
@@ -59,11 +53,6 @@ Setup
 
 To store your backups on the local file system, simply setup the required
 settings below. ::
-
-    DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
-    DBBACKUP_STORAGE_OPTIONS = {'location': '/my/backup/dir/'}
-
-Alternatively, starting from Django 4.2, you can use the STORAGES setting: ::
 
     STORAGES = {
         "dbbackup": {
@@ -107,11 +96,15 @@ In order to backup to Google cloud storage, you'll first need to create an accou
 
 Add the following to your project's settings. Strictly speaking only `bucket_name` is required, but we'd recommend to add the other two as well. You can also find more settings in the readme for `django-storages`_ ::
 
-    DBBACKUP_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
-    DBBACKUP_STORAGE_OPTIONS = {
-        "bucket_name": "your_bucket_name",
-        "project_id": "your_project_id",
-        "blob_chunk_size": 1024 * 1024
+    STORAGES = {
+        "dbbackup": {
+            "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+            "OPTIONS": {
+                "bucket_name": "your_bucket_name",
+                "project_id": "your_project_id",
+                "blob_chunk_size": 1024 * 1024,
+            },
+        },
     }
 
 .. _`django-storages`: https://django-storages.readthedocs.io/en/latest/backends/gcloud.html
@@ -134,12 +127,16 @@ complete, you can follow the required setup below. ::
 
 Add the following to your project's settings: ::
 
-    DBBACKUP_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
-    DBBACKUP_STORAGE_OPTIONS = {
-        'access_key': 'my_id',
-        'secret_key': 'my_secret',
-        'bucket_name': 'my_bucket_name',
-        'default_acl': 'private',
+    STORAGES = {
+        "dbbackup": {
+            "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+            "OPTIONS": {
+                "access_key": "my_id",
+                "secret_key": "my_secret",
+                "bucket_name": "my_bucket_name",
+                "default_acl": "private",
+            },
+        }
     }
 
 Available settings
@@ -233,11 +230,13 @@ Setup your Django project
 
 ...And make sure you have the following required settings: ::
 
-
-    DBBACKUP_STORAGE = 'storages.backends.dropbox.DropBoxStorage'
-    DBBACKUP_STORAGE_OPTIONS = {
-        'oauth2_access_token': 'my_token',
-    }
+    STORAGES = {
+        "dbbackup": {
+            "BACKEND": "storages.backends.dropbox.DropBoxStorage",
+            "OPTIONS": {
+                "oauth2_access_token": "my_token",
+            },
+        },
 
 Available settings
 ~~~~~~~~~~~~~~~~~~
@@ -276,9 +275,13 @@ Setup
 
 ::
 
-    DBBACKUP_STORAGE = 'storages.backends.ftp.FTPStorage
-    DBBACKUP_STORAGE_OPTIONS = {
-        'location': 'ftp://user:pass@server:21'
+    STORAGES = {
+        "dbbackup": {
+            "BACKEND": "storages.backends.ftp.FTPStorage",
+            "OPTIONS": {
+                "location": "ftp://user:pass@server:21",
+            },
+        },
     }
 
 Settings
@@ -297,8 +300,14 @@ We use FTP backend from Django-Storages (again). ::
 
 Here a simple configuration: ::
 
-    DBBACKUP_STORAGE = 'storages.backends.ftp.FTPStorage'
-    DBBACKUP_STORAGE_OPTIONS = {'location': ftp://myftpserver/}
+    STORAGES = {
+        "dbbackup": {
+            "BACKEND": "storages.backends.ftp.FTPStorage",
+            "OPTIONS": {
+                "location": "ftp://myftpserver/",
+            },
+        },
+    }
 
 SFTP
 ----
@@ -317,8 +326,15 @@ This backend is from Django-Storages with the `paramiko`_ backend. ::
 
 The following configuration grants SSH server access to the local user: ::
 
-    DBBACKUP_STORAGE = 'storages.backends.sftpstorage.SFTPStorage'
-    DBBACKUP_STORAGE_OPTIONS = {'host': 'myserver'}
+    STORAGES = {
+        "dbbackup": {
+            "BACKEND": "storages.backends.sftpstorage.SFTPStorage",
+            "OPTIONS": {
+                'host': 'myserver',
+            },
+        },
+    }
+
 
 
 .. _`paramiko SSHClient.connect() documentation`: https://docs.paramiko.org/en/latest/api/client.html#paramiko.client.SSHClient.connect

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-django>=3.2
+django>=4.2
 pytz

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Environment :: Console",
-        "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
         "Framework :: Django :: 5.1",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,310,311,312,313}-django{32,42,50,51,52,master},lint,docs,functional
+envlist = py{39,310,311,312,313}-django{42,50,51,52,master},lint,docs,functional
 
 [testenv]
 passenv = *
@@ -7,7 +7,6 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps =
     -rrequirements/tests.txt
-    django32: django>=3.2,<3.3
     django42: django>=4.2,<4.3
     django50: django>=5.0,<5.1
     django51: django>=5.1,<5.2
@@ -18,8 +17,8 @@ commands = {posargs:coverage run runtests.py}
 # Configure which test environments are run for each Github Actions Python version.
 [gh-actions]
 python =
-    3.9: py39-django{32,42},functional
-    3.10: py310-django{32,42,50,51,52},functional
+    3.9: py39-django{42},functional
+    3.10: py310-django{42,50,51,52},functional
     3.11: py311-django{42,50,51,52},functional
     3.12: py312-django{42,50,51,52},functional
     3.13: py313-django{51,52},functional

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps =
     django50: django>=5.0,<5.1
     django51: django>=5.1,<5.2
     django52: django>=5.2,<5.3
-    djangomaster: https://github.com/django/django/archive/master.zip
 commands = {posargs:coverage run runtests.py}
 
 # Configure which test environments are run for each Github Actions Python version.


### PR DESCRIPTION
## Description

Closes #526

- Also remove the **Compatibility** section from the documentation as it (clearly) can easily get stale. We don't test on PyPy and the Python versions supported were also very out of date. Users can look at our build metadata to supported Python and Django versions.
- Utilize `STORAGES` setting introduced in Django 4.2+, rather than our own `DBBACKUP_STORAGE` setting.

## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
