### PR TITLE
Fix compatibility with newer `gnupg` versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ __pycache__/
 .Python
 .env
 env/
-.venv
-venv/
+.venv*
+venv*
 build/
 develop-eggs/
 dist/
@@ -66,3 +66,6 @@ target/
 *.sw[po]
 test-sqlite
 venv
+
+# Other
+*memorydb_default*

--- a/dbbackup/tests/test_utils.py
+++ b/dbbackup/tests/test_utils.py
@@ -112,7 +112,7 @@ class Encrypt_FileTest(TestCase):
         clean_gpg_keys()
 
     def test_func(self, *args):
-        with open(self.path) as fd:
+        with open(self.path, mode="rb") as fd:
             encrypted_file, filename = utils.encrypt_file(
                 inputfile=fd, filename="foo.txt"
             )
@@ -146,7 +146,7 @@ class Compress_FileTest(TestCase):
         os.remove(self.path)
 
     def test_func(self, *args):
-        with open(self.path) as fd:
+        with open(self.path, mode="rb") as fd:
             compressed_file, filename = utils.encrypt_file(
                 inputfile=fd, filename="foo.txt"
             )

--- a/dbbackup/utils.py
+++ b/dbbackup/utils.py
@@ -174,6 +174,10 @@ def encrypt_file(inputfile, filename):
     try:
         filename = f"{filename}.gpg"
         filepath = os.path.join(tempdir, filename)
+        if "b" not in inputfile.mode:
+            raise ValueError(
+                "Input file must be opened in binary mode."
+            )
         try:
             inputfile.seek(0)
             always_trust = settings.GPG_ALWAYS_TRUST

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,7 +2,7 @@ coverage
 django-storages
 flake8
 pep8
-psycopg2
+psycopg2-binary
 pylint
 python-dotenv
 python-gnupg>=0.5.0


### PR DESCRIPTION
## Description

Newer versions of `gnupg` require files to be opened in binary mode. This PR adds checks within `encrypt_file` to ensure the is in binary mode.

## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
