### PR TITLE
Set default `IF_EXISTS` to `True` for PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Don't forget to remove deprecated code on each major release!
 - This repository has been transferred out of Jazzband due to logistical concerns.
 - Improve error message for missing database tools (`pg_dump`, `mysqldump`, etc.) to provide guidance instead of generic "No such file or directory" errors.
 - Changed default SQLite connector from `SqliteConnector` to `SqliteBackupConnector` to adhere to best practices.
+- Set default `IF_EXISTS` to `True` for PostgreSQL connectors (`PgDumpConnector` and `PgDumpBinaryConnector`) to reduce restore errors when objects are absent.
 
 ### Removed
 

--- a/dbbackup/db/postgresql.py
+++ b/dbbackup/db/postgresql.py
@@ -32,6 +32,7 @@ class PgDumpConnector(BaseCommandDBConnector):
     restore_cmd = "psql"
     single_transaction = True
     drop = True
+    if_exists = True
     schemas: Optional[List[str]] = []
 
     def _create_dump(self):
@@ -44,6 +45,9 @@ class PgDumpConnector(BaseCommandDBConnector):
 
         if self.drop:
             cmd += " --clean"
+
+        if self.if_exists or self.drop:
+            cmd += " --if-exists"
 
         if self.schemas:
             # First schema is not prefixed with -n
@@ -112,7 +116,7 @@ class PgDumpBinaryConnector(PgDumpConnector):
     restore_cmd = "pg_restore"
     single_transaction = True
     drop = True
-    if_exists = False
+    if_exists = True
     pg_options = None
 
     def _create_dump(self):

--- a/docs/src/databases.md
+++ b/docs/src/databases.md
@@ -114,7 +114,7 @@ All PostgreSQL connectors have the following settings:
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | SINGLE_TRANSACTION | Wrap restore in a single transaction so errors cause full rollback (`--single-transaction` for `psql` / `pg_restore`).                  | `True`  |
 | DROP               | Include / execute drop statements when restoring (`--clean` with `pg_dump` / `pg_restore`). In binary mode drops happen during restore. | `True`  |
-| IF_EXISTS          | Add `IF EXISTS` to destructive statements in clean mode. Automatically enabled when `DROP=True` to prevent identity column errors.      | `False` |
+| IF_EXISTS          | Add `IF EXISTS` to destructive statements in clean mode. Enabled by default, and when `DROP=True` to prevent identity column errors.    | `True`  |
 
 #### PgDumpBinaryConnector
 


### PR DESCRIPTION
## Description

Postgres always attempts to DROP previous tables before restoring. This is problematic when restoring to an empty/fresh database, since there is nothing to drop.

As a result, we are changing our default configuration values to account for this (`IF_EXISTS` is now `True`)

fix #245

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
