### PR TITLE
Fix GitHub publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,6 @@ jobs:
               run: |
                   echo "Version: ${{ steps.query-release-info.outputs.version }}"
                   echo "Date: ${{ steps.query-release-info.outputs.release-date }}"
-                  echo "${{ steps.query-release-info.outputs.release-notes }}"
             - uses: ncipollo/release-action@v1
               with:
                   artifacts: "dist/*.tar.gz,dist/*.whl"


### PR DESCRIPTION
## Description

GitHub publishing is broken because we are trying to `echo` a multi-line string, which is not possible.

## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
