### PR TITLE
Indicate that `STORAGES` configuration may have more keys

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -36,6 +36,7 @@ INSTALLED_APPS = (
 )
 
 STORAGES = {
+    ...,
     'dbbackup': {
         'BACKEND': 'django.core.files.storage.FileSystemStorage',
         'OPTIONS': {


### PR DESCRIPTION
## Description

When porting to django-dbbackup 5.0.0 and moving away from the deprecated `DBBACKUP_STORAGE` settings (#609), I went to the docs and didn't realize that adding `STORAGES` would override the Django defaults:

https://docs.djangoproject.com/en/5.2/ref/settings/#storages

This broke the `staticfiles`.

I think hinting that there could be more to this in the our docs (similar to `INSTALLED_APPS`) could help key people in to this detail.

## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
