### PR TITLE
Remove hardcoded logger level set in db/base.py

### DIFF
--- a/dbbackup/db/base.py
+++ b/dbbackup/db/base.py
@@ -16,7 +16,6 @@ from dbbackup import settings, utils
 from dbbackup.db import exceptions
 
 logger = logging.getLogger("dbbackup.command")
-logger.setLevel(logging.DEBUG)
 
 DEFAULT_CONNECTOR = "dbbackup.db.django.DjangoConnector"
 CONNECTOR_MAPPING = {


### PR DESCRIPTION
## Description

Remove the hardcoded debug logging level set in db/base.py

The logging in this file should conform to the log level set for the `dbackup.command` logger.

## Checklist

I don't think anything in this checklist are relevant for this change. Let me know if you think otherwise.

~Please update this checklist as you complete each item:~

~-   [ ] Tests have been developed for bug fixes or new functionality.~
~-   [ ] The changelog has been updated, if necessary.~
~-   [ ] Documentation has been updated, if necessary.~
~-   [ ] GitHub Issues closed by this PR have been linked.~

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
