### PR TITLE
Ensure metadata is always written as bytes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,7 @@ Bootstrap, build, and test the repository:
 - `hatch run functional:all` – end-to-end functional (SQLite + PostgreSQL live scripts) (≈10–15s) **NEVER CANCEL.**
   - `hatch run functional:sqlite --all` – only SQLite functional cycle
   - `hatch run functional:postgres --all` – only PostgreSQL functional cycle
-- `hatch run lint:check` – lint (ruff) (≈5s)
+- `hatch fmt --check` – lint (ruff) (≈5s)
 - `hatch run docs:build` – build documentation (≈2s, strict)
 - `hatch run docs:serve` – local docs server (http://localhost:8000)
 - `hatch run docs:linkcheck` – validate internal/external links & spelling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ Don't forget to remove deprecated code on each major release!
 
 ## [Unreleased]
 
--   Nothing (yet)!
+### Fixed
+
+-   Ensure `dbbackup` metadata file is always written as bytes to support storage backends that enforce bytes content (e.g. Google Cloud Storage).
 
 ## [5.1.0] - 2025-12-17
 

--- a/dbbackup/management/commands/dbbackup.py
+++ b/dbbackup/management/commands/dbbackup.py
@@ -108,7 +108,7 @@ class Command(BaseDbBackupCommand):
             with open(metadata_filename, "w") as fd:
                 fd.write(metadata_content)
         else:
-            metadata_file = ContentFile(metadata_content)
+            metadata_file = ContentFile(metadata_content.encode("utf-8"))
             self.write_to_storage(metadata_file, metadata_filename)
 
     def _save_new_backup(self, database):

--- a/tests/commands/test_dbbackup.py
+++ b/tests/commands/test_dbbackup.py
@@ -80,6 +80,22 @@ class DbbackupCommandSaveNewBackupTest(TestCase):
 
         assert result is None
 
+    def test_metadata_is_bytes(self):
+        """Test that metadata content is passed as bytes to storage."""
+        self.command._save_new_backup(TEST_DATABASE)
+
+        # Find the metadata file in HANDLED_FILES
+        # HANDLED_FILES["written_files"] contains tuples (name, file_object)
+        metadata_file_entry = next((f for f in HANDLED_FILES["written_files"] if f[0].endswith(".metadata")), None)
+        assert metadata_file_entry is not None
+
+        metadata_file = metadata_file_entry[1]
+        metadata_file.open()
+        content = metadata_file.read()
+
+        # Check if content is bytes
+        assert isinstance(content, bytes), f"Metadata content should be bytes, but got {type(content)}"
+
     @patch("dbbackup.management.commands._base.BaseDbBackupCommand.write_to_storage")
     def test_path_s3_uri(self, mock_write_to_storage):
         """Test that S3 URIs in output path are handled by write_to_storage instead of write_local_file."""

--- a/tests/commands/test_dbrestore_metadata.py
+++ b/tests/commands/test_dbrestore_metadata.py
@@ -189,9 +189,11 @@ class DbrestoreConnectorOverrideTest(TestCase):
         metadata = {"engine": settings.DATABASES["default"]["ENGINE"], "connector": "my.broken.Connector"}
         self.command.storage.read_file.return_value = Mock(read=lambda: json.dumps(metadata))
 
-        with patch("dbbackup.management.commands.dbrestore.import_module", side_effect=ImportError):
-            with pytest.raises(SystemExit):
-                self.command._restore_backup()
+        with (
+            patch("dbbackup.management.commands.dbrestore.import_module", side_effect=ImportError),
+            pytest.raises(SystemExit),
+        ):
+            self.command._restore_backup()
 
         # Verify input was called
         mock_input.assert_called()


### PR DESCRIPTION
## Description

Ensure `dbbackup` metadata file is always written as bytes to support storage backends that enforce bytes content (e.g. Google Cloud Storage).

## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
