### PR TITLE
Fix #672: --verbosity parameter not outputting log messages to console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Don't forget to remove deprecated code on each major release!
 
 - PostgreSQL `HOST` that are Unix/Windows socket paths will now be automatically URI-encoded to uphold `pg_restore` command line requirements.
 
+### Fixed
+
+- `--verbosity` parameter now correctly outputs log messages to the console instead of suppressing all output regardless of verbosity level.
+
 ## [5.3.0] - 2026-04-09
 
 ### Fixed

--- a/dbbackup/management/commands/_base.py
+++ b/dbbackup/management/commands/_base.py
@@ -85,6 +85,16 @@ class BaseDbBackupCommand(BaseCommand):
         level = 60 if self.quiet else LOGGING_VERBOSITY[int(self.verbosity)]
         self.logger.setLevel(level)
 
+        # Ensure a StreamHandler exists for console output so that
+        # --verbosity works regardless of the user's Django LOGGING
+        # configuration. We replace handlers (rather than appending)
+        # to guarantee only one stdout/terminal sink is active.
+        if not any(isinstance(h, logging.StreamHandler) for h in self.logger.handlers):
+            handler = logging.StreamHandler(sys.stderr)
+            handler.setLevel(level)
+            handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+            self.logger.addHandler(handler)
+
     def _ask_confirmation(self):
         answer = input("Are you sure you want to continue? [Y/n] ")
         if answer.lower().startswith("n"):

--- a/dbbackup/management/commands/_base.py
+++ b/dbbackup/management/commands/_base.py
@@ -85,11 +85,14 @@ class BaseDbBackupCommand(BaseCommand):
         level = 60 if self.quiet else LOGGING_VERBOSITY[int(self.verbosity)]
         self.logger.setLevel(level)
 
-        # Ensure a StreamHandler exists for console output so that
+        # Find or create a StreamHandler for console output so that
         # --verbosity works regardless of the user's Django LOGGING
-        # configuration. We replace handlers (rather than appending)
-        # to guarantee only one stdout/terminal sink is active.
-        if not any(isinstance(h, logging.StreamHandler) for h in self.logger.handlers):
+        # configuration. Only add one handler to avoid duplicates.
+        for handler in self.logger.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                handler.setLevel(level)
+                break
+        else:
             handler = logging.StreamHandler(sys.stderr)
             handler.setLevel(level)
             handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))


### PR DESCRIPTION
## Description

The `--verbosity` parameter was not working as expected. Regardless of verbosity level, no log messages were printed to the console during backup/restore operations.

**Root cause**: The `"dbbackup.command"` logger used by all management commands had no console `StreamHandler` attached. Messages propagated to the parent `"dbbackup"` logger, which only had an `AdminEmailHandler` at ERROR level — so all INFO/DEBUG/WARNING messages were silently swallowed.

**Fix**: In `_set_logger_level()`, automatically add a `StreamHandler` (writing to stderr) to the `"dbbackup.command"` logger when one doesn't already exist. This ensures that the verbosity setting properly controls console output, independent of the user's Django `LOGGING` configuration.

## Checklist

- [X] Tests have been developed for bug fixes or new functionality.
- [X] The changelog has been updated, if necessary.
- [ ] Documentation has been updated, if necessary.
- [X] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>