### PR TITLE
docs: add django default settings to installation guide

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -39,11 +39,16 @@ You need to configure at least one storage backend for database/media backups. T
 
 ```python
 STORAGES = {
-    ...,
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
     'dbbackup': {
         'BACKEND': 'django.core.files.storage.FileSystemStorage',
         'OPTIONS': {
-            'location': '/my/backup/dir/',
+            'location': '/home/furukawa/programming/beutelnet/src/beutelnet/data/backup',
         },
     },
 }


### PR DESCRIPTION
## Description
The current documentation for [Step 3: Choose a storage backend](https://archmonger.github.io/django-dbbackup/latest/installation/#step-3-choose-a-storage-backend) leaves the default setting for `STORAGES` blank.

When a first-time user copies and pastes the text into `settings.py` and runs `python manage.py dbbackup` it causes a `staticfiles.E005` error. 

Include the [Django >=4.2 default setting](https://docs.djangoproject.com/en/4.2/releases/4.2/) instead of the `...` to avoid the error and users having to search for the settings themselves.

## Checklist

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [ ] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
